### PR TITLE
C/map hooks

### DIFF
--- a/src/EsriMap.js
+++ b/src/EsriMap.js
@@ -12,17 +12,23 @@ function EsriMap ({ theme, onLoad }) {
   // need a reference for the view as well since we don't have instance fields
   // see: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
   const viewRef = useRef(null);
+  // need initial prop values when loading the map (see below)
+  const initialProps = useRef({ theme, onLoad });
 
   // load the ArcGIS JS API and map when the component mounts
   useEffect(() => {
     // hooks require inline functions in order to use async/await
-    async function initMap () {
+    async function initMap ({ theme, onLoad }) {
       // we need a reference to the view in other hooks
       viewRef.current = await loadMap(mapDiv.current, themeToBasemap(theme));
       // let the app know the map has loaded
       onLoad && onLoad();
     }
-    initMap();
+    // we can't use the props directly in this hook w/o depending on them
+    // and we can't depend on them if we want this hook to only run once
+    // so instead we get initial prop values via a ref
+    // see: https://github.com/facebook/react/issues/15865#issuecomment-540715333
+    initMap(initialProps.current);
     // destroy the view and map to prevent memory leaks
     // similar to componentWillUnmount()
     return function destroyMapView() {

--- a/src/EsriMap.js
+++ b/src/EsriMap.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import "./EsriMap.css";
 import { loadMap } from "./utils/map";
 
@@ -6,45 +6,43 @@ function themeToBasemap(theme) {
   return theme === "light" ? "gray-vector" : "dark-gray-vector";
 }
 
-class EsriMap extends React.Component {
-  constructor(props) {
-    super(props);
-    // get a reference to the div to use as the view's container
-    this.mapDiv = React.createRef();
-  }
+function EsriMap ({ theme, onLoad }) {
+  // get a reference to the div to use as the view's container
+  const mapDiv = useRef(null);
+  // need a reference for the view as well since we don't have instance fields
+  // see: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
+  const viewRef = useRef(null);
 
   // load the ArcGIS JS API and map when the component mounts
-  async componentDidMount() {
-    const { theme, onLoad } = this.props;
-    const container = this.mapDiv.current;
-    const basemap = themeToBasemap(theme);
-    // we need a reference to the view in other lifecycle methods
-    this._view = await loadMap(container, basemap);
-    // let the app know the map has loaded
-    onLoad && onLoad();
-  }
-
-  // update the basemap when the theme changes
-  componentDidUpdate(prevProps) {
-    if (this.props.theme !== prevProps.theme) {
-      if (this._view) {
-        this._view.map.basemap = themeToBasemap(this.props.theme);
+  useEffect(() => {
+    // hooks require inline functions in order to use async/await
+    async function initMap () {
+      // we need a reference to the view in other hooks
+      viewRef.current = await loadMap(mapDiv.current, themeToBasemap(theme));
+      // let the app know the map has loaded
+      onLoad && onLoad();
+    }
+    initMap();
+    // destroy the view and map to prevent memory leaks
+    // similar to componentWillUnmount()
+    return function destroyMapView() {
+      let _view = viewRef.current;
+      if (_view) {
+        _view = _view.container = null;
       }
     }
-  }
+  }, []); // causes this to only run once, similar to componentWillMount()
 
-  // destroy the view and map to prevent memory leaks
-  componentWillUnmount() {
-    if (this._view) {
-      this._view.container = null;
-      delete this._view;
+  // update the basemap when the theme changes
+  useEffect(() => {
+    const _view = viewRef.current;
+    if (_view) {
+      _view.map.basemap = themeToBasemap(theme);
     }
-  }
+  }, [theme]);
 
   // render a div to use as the view's container
-  render() {
-    return <div className="esri-map" ref={this.mapDiv} />;
-  }
+  return <div className="esri-map" ref={mapDiv} />;
 }
 
 export default EsriMap;


### PR DESCRIPTION
Convert `EsriMap` from a class-based component a hooks-based one.

Key ideas:
- use a [ref to replace instance variables](https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables) (h/t @gavinr)
- use multiple `useEffect()` calls:
  - one to replicate the behavior in `componentDidMount()` (load map) and `componentWillUpdate()` (tear down map)
  - one to replicate the `componentDidUpdate()` behavior (update basemap)
- [wrap any code that `await`s in `useEffect()` in an inline `async` function](https://reactjs.org/docs/hooks-faq.html#how-can-i-do-data-fetching-with-hooks)

The biggest challenge was figuring out how to use the `theme` and `onLoad` props when the component mounts. When I passed `[]` as the second argument to `useEffect()`, I would get warnings like: `React Hook useEffect has missing dependencies: 'onLoad' and 'theme'. Either include them or remove the dependency array` (7381ee9). I tried a couple different ways to get around this, but ultimately landed on using a ref to hold on to the initial values (d46a5c2).

For reference, here's what I'm trying to teach w/ this demo: 

https://github.com/tomwayson/arcgis-cra-demo#arcgis-cra-demo

Do those concepts get lost in all the hoops you gotta jump through for hooks?

