### PR TITLE
map hooks that use state to hold on to view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,18 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import './App.css';
 import EsriMap from "./EsriMap";
 
 function App () {
   const [theme, setTheme] = useState('light');
   const [mapLoaded, setMapLoaded] = useState(false);
-
-  const switchTheme = e => {
-    setTheme(e.target.dataset.theme);
-  };
-  const onMapLoad = () => {
+  const onMapLoad = useCallback(() => {
     setMapLoaded(true);
-  };
+  }, []);
+  const switchTheme = useCallback(e => {
+    setTheme(e.target.dataset.theme);
+  }, []);
   const appClassName = `App ${theme === "dark" ? "dark" : ""}`;
+
   return (
     <div className={appClassName}>
       <div>

--- a/src/EsriMap.js
+++ b/src/EsriMap.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import "./EsriMap.css";
 import { loadMap } from "./utils/map";
 
@@ -6,45 +6,49 @@ function themeToBasemap(theme) {
   return theme === "light" ? "gray-vector" : "dark-gray-vector";
 }
 
-class EsriMap extends React.Component {
-  constructor(props) {
-    super(props);
-    // get a reference to the div to use as the view's container
-    this.mapDiv = React.createRef();
-  }
+function EsriMap ({ theme, onLoad }) {
+  // get a reference to the div to use as the view's container
+  const mapDiv = useRef(null);
+  // we'll hold a reference to the map view in state
+  const [view, setView] = useState(null);
+  // need initial prop values when loading the map (see below)
+  const initialProps = useRef({ theme, onLoad });
 
   // load the ArcGIS JS API and map when the component mounts
-  async componentDidMount() {
-    const { theme, onLoad } = this.props;
-    const container = this.mapDiv.current;
-    const basemap = themeToBasemap(theme);
-    // we need a reference to the view in other lifecycle methods
-    this._view = await loadMap(container, basemap);
-    // let the app know the map has loaded
-    onLoad && onLoad();
-  }
-
-  // update the basemap when the theme changes
-  componentDidUpdate(prevProps) {
-    if (this.props.theme !== prevProps.theme) {
-      if (this._view) {
-        this._view.map.basemap = themeToBasemap(this.props.theme);
+  useEffect(() => {
+    // we need a closure scope so we can access the view in destroyView()
+    let _view;
+    // hooks require inline functions in order to use async/await
+    async function initMap ({ theme, onLoad }) {
+      // we need a reference to the view in other hooks
+      _view = await loadMap(mapDiv.current, themeToBasemap(theme));
+      setView(_view);
+      // let the app know the map has loaded
+      onLoad && onLoad();
+    }
+    // we can't use the props directly in this hook w/o depending on them
+    // and we can't depend on them if we want this hook to only run once
+    // so instead we get initial prop values via a ref
+    // see: https://github.com/facebook/react/issues/15865#issuecomment-540715333
+    initMap(initialProps.current);
+    // destroy the view and map to prevent memory leaks
+    // similar to componentWillUnmount()
+    return function destroyView() {
+      if (_view) {
+        _view = _view.container = null;
       }
     }
-  }
+  }, []); // causes this to only run once, similar to componentWillMount()
 
-  // destroy the view and map to prevent memory leaks
-  componentWillUnmount() {
-    if (this._view) {
-      this._view.container = null;
-      delete this._view;
+  // update the basemap when the theme changes
+  useEffect(() => {
+    if (view) {
+      view.map.basemap = themeToBasemap(theme);
     }
-  }
+  }, [view, theme]);
 
   // render a div to use as the view's container
-  render() {
-    return <div className="esri-map" ref={this.mapDiv} />;
-  }
+  return <div className="esri-map" ref={mapDiv} />;
 }
 
 export default EsriMap;

--- a/src/EsriMap.js
+++ b/src/EsriMap.js
@@ -12,19 +12,17 @@ function EsriMap ({ theme, onLoad }) {
   // we'll hold a reference to the map view in state
   const [view, setView] = useState(null);
   // need initial prop values when loading the map (see below)
-  const initialProps = useRef({ theme, onLoad });
+  const initialProps = useRef({ theme });
 
   // load the ArcGIS JS API and map when the component mounts
   useEffect(() => {
     // we need a closure scope so we can access the view in destroyView()
     let _view;
     // hooks require inline functions in order to use async/await
-    async function initMap ({ theme, onLoad }) {
+    async function initMap ({ theme }) {
       // we need a reference to the view in other hooks
       _view = await loadMap(mapDiv.current, themeToBasemap(theme));
       setView(_view);
-      // let the app know the map has loaded
-      onLoad && onLoad();
     }
     // we can't use the props directly in this hook w/o depending on them
     // and we can't depend on them if we want this hook to only run once
@@ -46,6 +44,13 @@ function EsriMap ({ theme, onLoad }) {
       view.map.basemap = themeToBasemap(theme);
     }
   }, [view, theme]);
+
+  // let the app know the map has loaded
+  useEffect(() => {
+    if (view && onLoad) {
+      onLoad();
+    }
+  }, [view, onLoad]);
 
   // render a div to use as the view's container
   return <div className="esri-map" ref={mapDiv} />;


### PR DESCRIPTION
This alternative to #1 uses state instead of a ref to hold on to the view. Ultimately this is probably better. The only additional cognitive load here is the [closure scoped variable needed to destroy the map](https://github.com/tomwayson/arcgis-cra-demo/pull/2/files#diff-2bd8e31fcccd591082969d9640ff7185R19-R20).
